### PR TITLE
NullPointerException fixes

### DIFF
--- a/src/main/java/balls/BallsInitializer.java
+++ b/src/main/java/balls/BallsInitializer.java
@@ -261,7 +261,7 @@ public class BallsInitializer implements
                 boolean rubberBandBallUsed = false;
                 boolean tennisBallUsed = false;
 
-                if(AbstractDungeon.player != null) {
+                if(AbstractDungeon.player != null && AbstractDungeon.player.relics != null) {
                     if (AbstractDungeon.player.hasRelic(BowlingBall.RELIC_ID)) {
                         bowlingBallActive = ((BowlingBall)AbstractDungeon.player.getRelic(BowlingBall.RELIC_ID)).doubleDamage;
                     }

--- a/src/main/java/balls/relics/Handball.java
+++ b/src/main/java/balls/relics/Handball.java
@@ -20,6 +20,6 @@ public class Handball extends AbstractBallRelic {
     public void onAttack(DamageInfo info, int damageAmount, AbstractCreature target) {
         AbstractMonster randomMonster = AbstractDungeon.getMonsters().getRandomMonster();
         if (randomMonster != null && info.type == DamageType.NORMAL)
-            randomMonster.damage(new DamageInfo(null, 2, DamageType.NORMAL));
+            randomMonster.damage(new DamageInfo(AbstractDungeon.player, 2, DamageType.NORMAL));
     }
 }


### PR DESCRIPTION
Seeing a few NPEs in my exception logs, seems like the Handball code is interacting poorly with quite a few other mods

Also fixing 1 random NPE I saw from the relics lookup, I think it has to be from .relics being null but I'm not 100% sure

Example Handball stack trace
`
java.lang.NullPointerException
	at balls.relics.Handball.onAttack(Handball.java:21)
	at com.megacrit.cardcrawl.characters.AbstractPlayer.damage(AbstractPlayer.java:1763)
	at thePackmaster.ThePackmaster.damage(ThePackmaster.java:108)
	at hugyourelics.relics.rare.MarkOfDecay.onPlayerHeal(MarkOfDecay.java:37)
	at com.megacrit.cardcrawl.core.AbstractCreature.heal(AbstractCreature.java:443)
	at com.megacrit.cardcrawl.core.AbstractCreature.increaseMaxHp(AbstractCreature.java:217)
	at foodbundle.relics.LemonfloatCommon.onEquip(LemonfloatCommon.java:27)
	at com.megacrit.cardcrawl.relics.AbstractRelic.instantObtain(AbstractRelic.java:250)
	at com.megacrit.cardcrawl.shop.StoreRelic.purchaseRelic(StoreRelic.java:101)
	at com.megacrit.cardcrawl.shop.StoreRelic.update(StoreRelic.java:78)
	at com.megacrit.cardcrawl.shop.ShopScreen.updateRelics(ShopScreen.java:1224)
	at com.megacrit.cardcrawl.shop.ShopScreen.update(ShopScreen.java:622)
	at com.megacrit.cardcrawl.dungeons.AbstractDungeon.update(AbstractDungeon.java:2587)
	at com.megacrit.cardcrawl.core.CardCrawlGame.update(CardCrawlGame.java:876)
	at com.megacrit.cardcrawl.core.CardCrawlGame.render(CardCrawlGame.java:423)
	at com.badlogic.gdx.backends.lwjgl.LwjglApplication.mainLoop(LwjglApplication.java:225)
	at com.badlogic.gdx.backends.lwjgl.LwjglApplication$1.run(LwjglApplication.java:126)
`

Relic lookup NPE:
`
java.lang.NullPointerException
	at balls.BallsInitializer$1.onSaveRaw(BallsInitializer.java:280)
	at basemod.patches.com.megacrit.cardcrawl.saveAndContinue.SaveFile.ConstructSaveFilePatch.Prefix(ConstructSaveFilePatch.java:93)
	at com.megacrit.cardcrawl.saveAndContinue.SaveFile.<init>(SaveFile.java:226)
	at com.megacrit.cardcrawl.helpers.SaveHelper.saveIfAppropriate(SaveHelper.java:280)
	at com.megacrit.cardcrawl.dungeons.AbstractDungeon.nextRoomTransition(AbstractDungeon.java:2202)
	at com.megacrit.cardcrawl.dungeons.AbstractDungeon.nextRoomTransition(AbstractDungeon.java:2119)
	at com.megacrit.cardcrawl.dungeons.AbstractDungeon.updateFading(AbstractDungeon.java:2848)
	at com.megacrit.cardcrawl.dungeons.AbstractDungeon.update(AbstractDungeon.java:2517)
	at com.megacrit.cardcrawl.core.CardCrawlGame.update(CardCrawlGame.java:876)
	at com.megacrit.cardcrawl.core.CardCrawlGame.render(CardCrawlGame.java:423)
	at com.badlogic.gdx.backends.lwjgl.LwjglApplication.mainLoop(LwjglApplication.java:225)
	at com.badlogic.gdx.backends.lwjgl.LwjglApplication$1.run(LwjglApplication.java:126)
`